### PR TITLE
Fix cursor stuck to splitter

### DIFF
--- a/Client/wwwroot/js/app.js
+++ b/Client/wwwroot/js/app.js
@@ -140,7 +140,7 @@ window.App.Repl = window.App.Repl || (function () {
                     'flex-basis': `${gutterSize}px`,
                 }),
                 onDrag: () => throttle(resetEditor, 100, 'resetEditor'),
-                onDragEnd: resetEditor
+                onDragEnd: () => resetEditor
             });
         }
     }


### PR DESCRIPTION
Hi from the MudBlazor team.
Time to give a tiny bit back.

We just updated to the HEAD of your master and found a problem with the splitter which is also live on your site.
If you drag the splitter you can never leave as it causes an exception in the onDragEnd delegate.
```
Uncaught TypeError: e.split is not a function
    at g.extractModeIds (/lib/monaco-editor/min/vs/editor/editor.main.js:128)
    at t.ModeServiceImpl.getModeId (/lib/monaco-editor/min/vs/editor/editor.main.js:128)
    at l._selector (/lib/monaco-editor/min/vs/editor/editor.main.js:128)
    at new l (/lib/monaco-editor/min/vs/editor/editor.main.js:128)
    at t.ModeServiceImpl.create (/lib/monaco-editor/min/vs/editor/editor.main.js:128)
    at Object.W [as createModel] (/lib/monaco-editor/min/vs/editor/editor.main.js:196)
    at new N (/lib/monaco-editor/min/vs/editor/editor.main.js:196)
    at /lib/monaco-editor/min/vs/editor/editor.main.js:196
    at R (/lib/monaco-editor/min/vs/editor/editor.main.js:196)
    at Object.T [as create] (/lib/monaco-editor/min/vs/editor/editor.main.js:196)
```
This very small PR fixes that
Thanks again for all you work.

cc @henon